### PR TITLE
Update Links & Go Module Path to New Github Org: Svix

### DIFF
--- a/.github/workflows/other-lint.yml
+++ b/.github/workflows/other-lint.yml
@@ -33,4 +33,5 @@ jobs:
           VALIDATE_PYTHON_MYPY: false
           VALIDATE_PYTHON_PYLINT: false
           VALIDATE_GO: false
+          VALIDATE_JSCPD: false
           FILTER_REGEX_EXCLUDE: (java/gradlew)

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-<p align="center">
+<h1 align="center">
   <img width="120" src="https://avatars.githubusercontent.com/u/80175132?s=200&v=4" />
-  <h1 align="center">Svix - Webhooks as a service</h1>
-</p>
+  <p align="center">Svix - Webhooks as a service</p>
+</h1>
 
 Libraries for interacting with the Svix API and verifying webhook signatures
 
-![GitHub tag](https://img.shields.io/github/tag/svixhq/svix-libs.svg)
+![GitHub tag](https://img.shields.io/github/tag/svix/svix-libs.svg)
 [![PyPI](https://img.shields.io/pypi/v/svix.svg)](https://pypi.python.org/pypi/svix/)
 [![NPM version](https://img.shields.io/npm/v/svix.svg)](https://www.npmjs.com/package/svix)
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/svixhq/svix-libs)](https://pkg.go.dev/github.com/svixhq/svix-libs)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/svix/svix-libs)](https://pkg.go.dev/github.com/svix/svix-libs)
 [![Join our slack](https://img.shields.io/badge/Slack-join%20the%20community-blue?logo=slack&style=social)](https://www.svix.com/slack/)
 
 # Documentation
 
-The docs are available at https://docs.svix.com
+The docs are available at <https://docs.svix.com>
 
 # Structure
 
@@ -22,7 +22,7 @@ The code is a combination of code auto-generated from the OpenAPI spec, and manu
 
 # Building
 
-```
+```sh
 # Install deps
 yarn
 ./regen_openapi.sh https://api.svix.com/api/v1/openapi.json

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/svixhq/svix-libs
+module github.com/svix/svix-libs
 
 go 1.16
 

--- a/go/application.go
+++ b/go/application.go
@@ -3,7 +3,7 @@ package svix
 import (
 	"context"
 
-	"github.com/svixhq/svix-libs/go/internal/openapi"
+	"github.com/svix/svix-libs/go/internal/openapi"
 )
 
 type (

--- a/go/authentication.go
+++ b/go/authentication.go
@@ -3,7 +3,7 @@ package svix
 import (
 	"context"
 
-	"github.com/svixhq/svix-libs/go/internal/openapi"
+	"github.com/svix/svix-libs/go/internal/openapi"
 )
 
 type Authentication struct {

--- a/go/endpoint.go
+++ b/go/endpoint.go
@@ -3,7 +3,7 @@ package svix
 import (
 	"context"
 
-	"github.com/svixhq/svix-libs/go/internal/openapi"
+	"github.com/svix/svix-libs/go/internal/openapi"
 )
 
 type (

--- a/go/eventtype.go
+++ b/go/eventtype.go
@@ -3,7 +3,7 @@ package svix
 import (
 	"context"
 
-	"github.com/svixhq/svix-libs/go/internal/openapi"
+	"github.com/svix/svix-libs/go/internal/openapi"
 )
 
 type EventType struct {

--- a/go/message.go
+++ b/go/message.go
@@ -3,7 +3,7 @@ package svix
 import (
 	"context"
 
-	"github.com/svixhq/svix-libs/go/internal/openapi"
+	"github.com/svix/svix-libs/go/internal/openapi"
 )
 
 type Message struct {

--- a/go/messageattempt.go
+++ b/go/messageattempt.go
@@ -3,7 +3,7 @@ package svix
 import (
 	"context"
 
-	"github.com/svixhq/svix-libs/go/internal/openapi"
+	"github.com/svix/svix-libs/go/internal/openapi"
 )
 
 type MessageAttempt struct {

--- a/go/svix.go
+++ b/go/svix.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/svixhq/svix-libs/go/internal/openapi"
+	"github.com/svix/svix-libs/go/internal/openapi"
 )
 
 type (

--- a/go/webhook_test.go
+++ b/go/webhook_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	svix "github.com/svixhq/svix-libs/go"
+	svix "github.com/svix/svix-libs/go"
 )
 
 func TestWebhook(t *testing.T) {

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -3,7 +3,7 @@
   "version": "0.16.0",
   "description": "Svix API client",
   "author": "svix",
-  "repository": "https://github.com/svixhq/svix-libs",
+  "repository": "https://github.com/svix/svix-libs",
   "type": "commonjs",
   "keywords": [
     "svix",

--- a/php/README.md
+++ b/php/README.md
@@ -19,7 +19,7 @@ require __DIR__ . '/vendor/autoload.php';
 
 ## Manual Installation
 
-For now you can download the [latest release](https://github.com/svixhq/svix-libs/releases). Then, to use the bindings, include the `init.php` file.
+For now you can download the [latest release](https://github.com/svix/svix-libs/releases). Then, to use the bindings, include the `init.php` file.
 
 ```php
 require_once('/path/to/svix-php/init.php');
@@ -29,7 +29,7 @@ require_once('/path/to/svix-php/init.php');
 
 Svix PHP requires the following extensions in order to run:
 
--   [`json`](https://secure.php.net/manual/en/book.json.php)
+- [`json`](https://secure.php.net/manual/en/book.json.php)
 
 If you use Composer, these dependencies should be handled automatically. If you install manually, you'll want to make sure that these extensions are available.
 

--- a/ruby/svix.gemspec
+++ b/ruby/svix.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
     spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
     spec.metadata["homepage_uri"] = spec.homepage
-    spec.metadata["source_code_uri"] = "https://github.com/svixhq/svix-libs"
-    spec.metadata["changelog_uri"] = "https://github.com/svixhq/svix-libs/blob/main/ChangeLog.md"
+    spec.metadata["source_code_uri"] = "https://github.com/svix/svix-libs"
+    spec.metadata["changelog_uri"] = "https://github.com/svix/svix-libs/blob/main/ChangeLog.md"
   else
     raise "RubyGems 2.0 or newer is required to protect against " \
       "public gem pushes."


### PR DESCRIPTION
We'll want a new release before we start telling people to use `github.com/svix/svix-libs` in go as modules are pretty particular about module declarations matching `go get` paths.