### PR TITLE
Python: Export 'WebhookVerificationError'

### DIFF
--- a/python/svix/__init__.py
+++ b/python/svix/__init__.py
@@ -10,4 +10,4 @@ from .api import (  # noqa
     Svix,
     SvixOptions,
 )
-from .receiver import Webhook  # noqa
+from .receiver import Webhook, WebhookVerificationError # noqa

--- a/python/svix/__init__.py
+++ b/python/svix/__init__.py
@@ -10,4 +10,4 @@ from .api import (  # noqa
     Svix,
     SvixOptions,
 )
-from .receiver import Webhook, WebhookVerificationError # noqa
+from .receiver import Webhook, WebhookVerificationError  # noqa


### PR DESCRIPTION
Export WebhookVerificationError in order to allow catching a validation exception.