### PR TITLE
tests: Add Multi Signature Tests

### DIFF
--- a/go/webhook_test.go
+++ b/go/webhook_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 )
@@ -95,6 +96,20 @@ func TestWebhook(t *testing.T) {
 			name:        "new timestamp fails",
 			testPayload: newTestPayload(time.Now().Add(tolerance + time.Second)),
 			expectedErr: true,
+		},
+		{
+			name:        "valid multi sig is valid",
+			testPayload: newTestPayload(time.Now()),
+			modifyPayload: func(tp *testPayload) {
+				sigs := []string{
+					"v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+					"v2,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+					tp.header.Get("svix-signature"), // valid signature
+					"v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+				}
+				tp.header.Set("svix-signature", strings.Join(sigs, " "))
+			},
+			expectedErr: false,
 		},
 	}
 

--- a/java/lib/src/main/java/com/svix/Webhook.java
+++ b/java/lib/src/main/java/com/svix/Webhook.java
@@ -6,7 +6,6 @@ import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
-import java.util.List;
 import java.util.Optional;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -29,7 +28,7 @@ public final class Webhook {
 
 	public void verify(final String payload, final HttpHeaders headers) throws WebhookVerificationException {
 		Optional<String> msgId = headers.firstValue(MSG_ID_KEY);
-		List<String> msgSignature = headers.allValues(MSG_SIGNATURE_KEY);
+		Optional<String> msgSignature = headers.firstValue(MSG_SIGNATURE_KEY);
 		Optional<String> msgTimestamp = headers.firstValue(MSG_TIMESTAMP_KEY);
 
 		if (msgId.isEmpty() || msgSignature.isEmpty() || msgTimestamp.isEmpty()) {
@@ -40,7 +39,8 @@ public final class Webhook {
 
 		String toSign = String.format("%s.%s.%s", msgId.get(), msgTimestamp.get(), payload);
 		String expectedSignature = Webhook.sign(key, toSign);
-		for (String versionedSignature : msgSignature) {
+		String[] msgSignatures = msgSignature.get().split(" ");
+		for (String versionedSignature : msgSignatures) {
 			String[] sigParts = versionedSignature.split(",");
 			if (sigParts.length < 2) {
 				continue;

--- a/java/lib/src/test/java/com/svix/WebhookTest.java
+++ b/java/lib/src/test/java/com/svix/WebhookTest.java
@@ -32,9 +32,15 @@ public class WebhookTest {
 	}
 
 	@Test
-	public void verifyValidPayloadAndheaderWithMultiplePayloads() throws WebhookVerificationException {
+	public void verifyValidPayloadWithMultipleSignaturesIsValid() throws WebhookVerificationException {
 		TestPayload testPayload = new TestPayload(System.currentTimeMillis());
-		testPayload.headerMap.get("svix-signature").add(0, "v2,tmIKtSyZlE3uFJELVlNIOLJ1OE=");
+		String[] sigs = new String[] {
+			"v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+			"v2,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+			testPayload.headerMap.get("svix-signature").get(0), // valid signature
+			"v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+		};
+		testPayload.headerMap.put("svix-signature", new ArrayList<String>(Arrays.asList(String.join(" ", sigs))));
 
 		Webhook webhook = new Webhook(testPayload.secret);
 

--- a/javascript/src/webhook.test.ts
+++ b/javascript/src/webhook.test.ts
@@ -115,3 +115,18 @@ test("new timestamp fails", () => {
     wh.verify(testPayload.payload, testPayload.header);
   }).toThrowError(WebhookVerificationError);
 });
+
+test("multi sig payload is valid", () => {
+  const wh = new Webhook("MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw");
+
+  const testPayload = new TestPayload();
+  const sigs = [
+    "v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+    "v2,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+    testPayload.header["svix-signature"], // valid signature
+    "v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+  ];
+  testPayload.header["svix-signature"] = sigs.join(" ");
+
+  wh.verify(testPayload.payload, testPayload.header);
+});

--- a/php/tests/WebhookTest.php
+++ b/php/tests/WebhookTest.php
@@ -89,4 +89,19 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
         $wh = new \Svix\Webhook($testPayload->secret);
         $wh->verify($testPayload->payload, $testPayload->header);
     }
+
+    public function testMultiSigPayloadIsValid()
+    {
+        $testPayload = new TestPayload(time());
+        $sigs = [
+            "v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+            "v2,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+            $testPayload->header['svix-signature'], // valid signature
+            "v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+        ];
+        $testPayload->header['svix-signature'] = implode(" ", $sigs);
+
+        $wh = new \Svix\Webhook($testPayload->secret);
+        $wh->verify($testPayload->payload, $testPayload->header);
+    }
 }

--- a/python/tests/test_receiver.py
+++ b/python/tests/test_receiver.py
@@ -13,6 +13,7 @@ defaultSecret = 'MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw'
 
 tolerance = timedelta(minutes=5)
 
+
 class PayloadForTesting:
     id: str
     timestamp: int
@@ -105,3 +106,18 @@ def test_new_timestamp_fails():
     
     with pytest.raises(WebhookVerificationError):
         wh.verify(testPayload.payload, testPayload.header)
+
+def test_multi_sig_payload_is_valid():
+    testPayload = PayloadForTesting()
+    sigs = [
+        "v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+        "v2,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+        testPayload.header["svix-signature"], # valid signature
+        "v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+    ]
+    testPayload.header["svix-signature"] = " ".join(sigs)
+
+    wh = Webhook(testPayload.secret)
+
+    json = wh.verify(testPayload.payload, testPayload.header)
+    assert json["test"] == 2432232314

--- a/ruby/spec/webhook_spec.rb
+++ b/ruby/spec/webhook_spec.rb
@@ -104,4 +104,20 @@ describe Svix::Webhook do
 
         expect { wh.verify(testPayload.payload, testPayload.headers) }.to raise_error(Svix::WebhookVerificationError)
     end
+
+    it "multi sig pyload is valid" do
+        testPayload = TestPayload.new
+        sigs = [
+            "v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+            "v2,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+            testPayload.headers["svix-signature"], # valid signature
+            "v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+        ]
+        testPayload.headers["svix-signature"] = sigs.join(" ")
+
+        wh = Svix::Webhook.new(testPayload.secret)
+
+        json = wh.verify(testPayload.payload, testPayload.headers)
+        expect(json[:test]).to eq(2432232314)
+    end
 end


### PR DESCRIPTION
Assuming that multi-sig payloads will always have all of the signature set as a single `svix-signature` header and not multiple ones.

Closes #55 