### PR TITLE
Java: Fix sources generation

### DIFF
--- a/java/deploy.gradle
+++ b/java/deploy.gradle
@@ -108,7 +108,7 @@ afterEvaluate { project ->
 
     task sourcesJar(type: Jar) {
         classifier = "sources"
-        from jar.destinationDir
+        from sourceSets.main.allSource
     }
 
     task javadocJar(type: Jar, dependsOn: javadoc) {


### PR DESCRIPTION
The previous path caused the built jars to be included in the sources jar, increasing the build size and time