### PR TITLE
Python: Disable return type checking

### DIFF
--- a/python/svix/api.py
+++ b/python/svix/api.py
@@ -74,11 +74,13 @@ class Authentication(ApiBase[AuthenticationApi]):
 
     def dashboard_access(self, app_id: str) -> DashboardAccessOut:
         with self._api() as api:
-            return api.get_dashboard_access_api_v1_auth_dashboard_access_app_id_post(app_id=app_id)
+            return api.get_dashboard_access_api_v1_auth_dashboard_access_app_id_post(
+                app_id=app_id, _check_return_type=False
+            )
 
     def logout(self) -> None:
         with self._api() as api:
-            return api.logout_api_v1_auth_logout_post()
+            return api.logout_api_v1_auth_logout_post(_check_return_type=False)
 
 
 class Application(ApiBase[ApplicationApi]):
@@ -86,23 +88,25 @@ class Application(ApiBase[ApplicationApi]):
 
     def list(self, options: FetchOptions = FetchOptions()) -> ListResponseApplicationOut:
         with self._api() as api:
-            return api.list_applications_api_v1_app_get(**options.to_dict())
+            return api.list_applications_api_v1_app_get(**options.to_dict(), _check_return_type=False)
 
     def create(self, application_in: ApplicationIn) -> ApplicationOut:
         with self._api() as api:
-            return api.create_application_api_v1_app_post(application_in=application_in)
+            return api.create_application_api_v1_app_post(application_in=application_in, _check_return_type=False)
 
     def get(self, app_id: str) -> ApplicationOut:
         with self._api() as api:
-            return api.get_application_api_v1_app_app_id_get(app_id=app_id)
+            return api.get_application_api_v1_app_app_id_get(app_id=app_id, _check_return_type=False)
 
     def update(self, app_id: str, application_in: ApplicationIn) -> ApplicationOut:
         with self._api() as api:
-            return api.update_application_api_v1_app_app_id_put(app_id=app_id, application_in=application_in)
+            return api.update_application_api_v1_app_app_id_put(
+                app_id=app_id, application_in=application_in, _check_return_type=False
+            )
 
     def delete(self, app_id: str) -> None:
         with self._api() as api:
-            return api.delete_application_api_v1_app_app_id_delete(app_id=app_id)
+            return api.delete_application_api_v1_app_app_id_delete(app_id=app_id, _check_return_type=False)
 
 
 class Endpoint(ApiBase[EndpointApi]):
@@ -110,32 +114,38 @@ class Endpoint(ApiBase[EndpointApi]):
 
     def list(self, app_id: str, options: FetchOptions = FetchOptions()) -> ListResponseEndpointOut:
         with self._api() as api:
-            return api.list_endpoints_api_v1_app_app_id_endpoint_get(app_id=app_id, **options.to_dict())
+            return api.list_endpoints_api_v1_app_app_id_endpoint_get(
+                app_id=app_id, **options.to_dict(), _check_return_type=False
+            )
 
     def create(self, app_id: str, endpoint_in: EndpointIn) -> EndpointOut:
         with self._api() as api:
-            return api.create_endpoint_api_v1_app_app_id_endpoint_post(app_id, endpoint_in=endpoint_in)
+            return api.create_endpoint_api_v1_app_app_id_endpoint_post(
+                app_id, endpoint_in=endpoint_in, _check_return_type=False
+            )
 
     def get(self, app_id: str, endpoint_id: str) -> EndpointOut:
         with self._api() as api:
-            return api.get_endpoint_api_v1_app_app_id_endpoint_endpoint_id_get(app_id=app_id, endpoint_id=endpoint_id)
+            return api.get_endpoint_api_v1_app_app_id_endpoint_endpoint_id_get(
+                app_id=app_id, endpoint_id=endpoint_id, _check_return_type=False
+            )
 
     def update(self, app_id: str, endpoint_id: str, endpoint_in: EndpointIn) -> EndpointOut:
         with self._api() as api:
             return api.update_endpoint_api_v1_app_app_id_endpoint_endpoint_id_put(
-                app_id=app_id, endpoint_id=endpoint_id, endpoint_in=endpoint_in
+                app_id=app_id, endpoint_id=endpoint_id, endpoint_in=endpoint_in, _check_return_type=False
             )
 
     def delete(self, app_id: str, endpoint_id: str) -> None:
         with self._api() as api:
             return api.delete_endpoint_api_v1_app_app_id_endpoint_endpoint_id_delete(
-                app_id=app_id, endpoint_id=endpoint_id
+                app_id=app_id, endpoint_id=endpoint_id, _check_return_type=False
             )
 
     def get_secret(self, app_id: str, endpoint_id: str) -> EndpointSecretOut:
         with self._api() as api:
             return api.get_endpoint_secret_api_v1_app_app_id_endpoint_endpoint_id_secret_get(
-                app_id=app_id, endpoint_id=endpoint_id
+                app_id=app_id, endpoint_id=endpoint_id, _check_return_type=False
             )
 
 
@@ -144,21 +154,23 @@ class EventType(ApiBase[EventTypeApi]):
 
     def list(self, options: FetchOptions = FetchOptions()) -> ListResponseEventTypeOut:
         with self._api() as api:
-            return api.list_event_types_api_v1_event_type_get(**options.to_dict())
+            return api.list_event_types_api_v1_event_type_get(**options.to_dict(), _check_return_type=False)
 
     def create(self, event_type_in: EventTypeIn) -> EventTypeOut:
         with self._api() as api:
-            return api.create_event_type_api_v1_event_type_post(event_type_in=event_type_in)
+            return api.create_event_type_api_v1_event_type_post(event_type_in=event_type_in, _check_return_type=False)
 
     def update(self, event_type_name: str, event_type_update: EventTypeUpdate) -> EventTypeOut:
         with self._api() as api:
             return api.update_event_type_api_v1_event_type_event_type_name_put(
-                event_type_name=event_type_name, event_type_update=event_type_update
+                event_type_name=event_type_name, event_type_update=event_type_update, _check_return_type=False
             )
 
     def delete(self, event_type_name: str) -> None:
         with self._api() as api:
-            return api.delete_event_type_api_v1_event_type_event_type_name_delete(event_type_name=event_type_name)
+            return api.delete_event_type_api_v1_event_type_event_type_name_delete(
+                event_type_name=event_type_name, _check_return_type=False
+            )
 
 
 class Message(ApiBase[MessageApi]):
@@ -166,15 +178,21 @@ class Message(ApiBase[MessageApi]):
 
     def list(self, app_id: str, options: FetchOptions = FetchOptions()) -> ListResponseMessageOut:
         with self._api() as api:
-            return api.list_messages_api_v1_app_app_id_msg_get(app_id=app_id, **options.to_dict())
+            return api.list_messages_api_v1_app_app_id_msg_get(
+                app_id=app_id, **options.to_dict(), _check_return_type=False
+            )
 
     def create(self, app_id: str, message_in: MessageIn) -> MessageOut:
         with self._api() as api:
-            return api.create_message_api_v1_app_app_id_msg_post(app_id=app_id, message_in=message_in)
+            return api.create_message_api_v1_app_app_id_msg_post(
+                app_id=app_id, message_in=message_in, _check_return_type=False
+            )
 
     def get(self, app_id: str, msg_id: str) -> MessageOut:
         with self._api() as api:
-            return api.get_message_api_v1_app_app_id_msg_msg_id_get(app_id=app_id, msg_id=msg_id)
+            return api.get_message_api_v1_app_app_id_msg_msg_id_get(
+                app_id=app_id, msg_id=msg_id, _check_return_type=False
+            )
 
 
 class MessageAttempt(ApiBase[MessageAttemptApi]):
@@ -185,19 +203,19 @@ class MessageAttempt(ApiBase[MessageAttemptApi]):
     ) -> ListResponseMessageAttemptOut:
         with self._api() as api:
             return api.list_attempts_api_v1_app_app_id_msg_msg_id_attempt_get(
-                app_id=app_id, msg_id=msg_id, **options.to_dict()
+                app_id=app_id, msg_id=msg_id, **options.to_dict(), _check_return_type=False
             )
 
     def get(self, app_id: str, msg_id: str, attempt_id: str) -> MessageAttemptOut:
         with self._api() as api:
             return api.get_attempt_api_v1_app_app_id_msg_msg_id_attempt_attempt_id_get(
-                app_id=app_id, msg_id=msg_id, attempt_id=attempt_id
+                app_id=app_id, msg_id=msg_id, attempt_id=attempt_id, _check_return_type=False
             )
 
     def resend(self, app_id: str, msg_id: str, endpoint_id: str) -> MessageAttemptOut:
         with self._api() as api:
             return api.resend_webhook_api_v1_app_app_id_msg_msg_id_endpoint_endpoint_id_resend_post(
-                app_id=app_id, msg_id=msg_id, endpoint_id=endpoint_id
+                app_id=app_id, msg_id=msg_id, endpoint_id=endpoint_id, _check_return_type=False
             )
 
 


### PR DESCRIPTION
It looks like the openapi-generator code is checking optional fields as required on return types, I haven't had a chance to dive deep into why it is actually happening but I figure we can just disable it for now which "fixes" the problem, I'll open an issue with openapi about it.

Context:
When making any calls that return classes with optional fields it checks them as required and errors out.
for example:
`svix.message.create("app_ID", MessageIn(event_type="test", payload={}))`
throws:
`svix.openapi_client.exceptions.ApiTypeError: Invalid type for variable 'event_id'. Required value type is str and passed type was NoneType at ['received_data']['event_id']`
