### PR TITLE
Bump openapi-generator, fixes python throwing when additional types are present

### DIFF
--- a/go/internal/openapi/client.go
+++ b/go/internal/openapi/client.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net/http"
@@ -118,7 +119,7 @@ func selectHeaderAccept(accepts []string) string {
 	return strings.Join(accepts, ",")
 }
 
-// contains is a case insenstive match, finding needle in a haystack
+// contains is a case insensitive match, finding needle in a haystack
 func contains(haystack []string, needle string) bool {
 	for _, a := range haystack {
 		if strings.ToLower(a) == strings.ToLower(needle) {
@@ -174,7 +175,6 @@ func parameterToJson(obj interface{}) (string, error) {
 	}
 	return string(jsonBuf), err
 }
-
 
 // callAPI do the request.
 func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
@@ -378,6 +378,15 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
+	if f, ok := v.(**os.File); ok {
+		*f, err = ioutil.TempFile("", "HttpClientFile")
+		if err != nil {
+			return
+		}
+		_, err = (*f).Write(b)
+		_, err = (*f).Seek(0, io.SeekStart)
+		return
+	}
 	if xmlCheck.MatchString(contentType) {
 		if err = xml.Unmarshal(b, v); err != nil {
 			return err
@@ -385,9 +394,9 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		return nil
 	}
 	if jsonCheck.MatchString(contentType) {
-		if actualObj, ok := v.(interface{GetActualInstance() interface{}}); ok { // oneOf, anyOf schemas
-			if unmarshalObj, ok := actualObj.(interface{UnmarshalJSON([]byte) error}); ok { // make sure it has UnmarshalJSON defined
-				if err = unmarshalObj.UnmarshalJSON(b); err!= nil {
+		if actualObj, ok := v.(interface{ GetActualInstance() interface{} }); ok { // oneOf, anyOf schemas
+			if unmarshalObj, ok := actualObj.(interface{ UnmarshalJSON([]byte) error }); ok { // make sure it has UnmarshalJSON defined
+				if err = unmarshalObj.UnmarshalJSON(b); err != nil {
 					return err
 				}
 			} else {
@@ -431,6 +440,8 @@ func setBody(body interface{}, contentType string) (bodyBuf *bytes.Buffer, err e
 
 	if reader, ok := body.(io.Reader); ok {
 		_, err = bodyBuf.ReadFrom(reader)
+	} else if fp, ok := body.(**os.File); ok {
+		_, err = bodyBuf.ReadFrom(*fp)
 	} else if b, ok := body.([]byte); ok {
 		_, err = bodyBuf.Write(b)
 	} else if s, ok := body.(string); ok {

--- a/go/internal/openapi/model_application_in.go
+++ b/go/internal/openapi/model_application_in.go
@@ -24,7 +24,7 @@ type ApplicationIn struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewApplicationIn(name string, ) *ApplicationIn {
+func NewApplicationIn(name string) *ApplicationIn {
 	this := ApplicationIn{}
 	this.Name = name
 	return &this
@@ -40,7 +40,7 @@ func NewApplicationInWithDefaults() *ApplicationIn {
 
 // GetName returns the Name field value
 func (o *ApplicationIn) GetName() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}

--- a/go/internal/openapi/model_application_out.go
+++ b/go/internal/openapi/model_application_out.go
@@ -27,7 +27,7 @@ type ApplicationOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewApplicationOut(createdAt time.Time, id string, name string, ) *ApplicationOut {
+func NewApplicationOut(createdAt time.Time, id string, name string) *ApplicationOut {
 	this := ApplicationOut{}
 	this.CreatedAt = createdAt
 	this.Id = id
@@ -45,7 +45,7 @@ func NewApplicationOutWithDefaults() *ApplicationOut {
 
 // GetCreatedAt returns the CreatedAt field value
 func (o *ApplicationOut) GetCreatedAt() time.Time {
-	if o == nil  {
+	if o == nil {
 		var ret time.Time
 		return ret
 	}
@@ -69,7 +69,7 @@ func (o *ApplicationOut) SetCreatedAt(v time.Time) {
 
 // GetId returns the Id field value
 func (o *ApplicationOut) GetId() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -93,7 +93,7 @@ func (o *ApplicationOut) SetId(v string) {
 
 // GetName returns the Name field value
 func (o *ApplicationOut) GetName() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}

--- a/go/internal/openapi/model_dashboard_access_out.go
+++ b/go/internal/openapi/model_dashboard_access_out.go
@@ -24,7 +24,7 @@ type DashboardAccessOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewDashboardAccessOut(token string, url string, ) *DashboardAccessOut {
+func NewDashboardAccessOut(token string, url string) *DashboardAccessOut {
 	this := DashboardAccessOut{}
 	this.Token = token
 	this.Url = url
@@ -41,7 +41,7 @@ func NewDashboardAccessOutWithDefaults() *DashboardAccessOut {
 
 // GetToken returns the Token field value
 func (o *DashboardAccessOut) GetToken() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -65,7 +65,7 @@ func (o *DashboardAccessOut) SetToken(v string) {
 
 // GetUrl returns the Url field value
 func (o *DashboardAccessOut) GetUrl() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}

--- a/go/internal/openapi/model_endpoint_in.go
+++ b/go/internal/openapi/model_endpoint_in.go
@@ -27,7 +27,7 @@ type EndpointIn struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewEndpointIn(url string, version int32, ) *EndpointIn {
+func NewEndpointIn(url string, version int32) *EndpointIn {
 	this := EndpointIn{}
 	var description string = ""
 	this.Description = &description
@@ -148,7 +148,7 @@ func (o *EndpointIn) SetFilterTypes(v []string) {
 
 // GetUrl returns the Url field value
 func (o *EndpointIn) GetUrl() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -172,7 +172,7 @@ func (o *EndpointIn) SetUrl(v string) {
 
 // GetVersion returns the Version field value
 func (o *EndpointIn) GetVersion() int32 {
-	if o == nil  {
+	if o == nil {
 		var ret int32
 		return ret
 	}

--- a/go/internal/openapi/model_endpoint_message_out.go
+++ b/go/internal/openapi/model_endpoint_message_out.go
@@ -29,7 +29,7 @@ type EndpointMessageOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewEndpointMessageOut(eventType string, id string, payload map[string]interface{}, status MessageStatus, timestamp time.Time, ) *EndpointMessageOut {
+func NewEndpointMessageOut(eventType string, id string, payload map[string]interface{}, status MessageStatus, timestamp time.Time) *EndpointMessageOut {
 	this := EndpointMessageOut{}
 	this.EventType = eventType
 	this.Id = id
@@ -81,7 +81,7 @@ func (o *EndpointMessageOut) SetEventId(v string) {
 
 // GetEventType returns the EventType field value
 func (o *EndpointMessageOut) GetEventType() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -105,7 +105,7 @@ func (o *EndpointMessageOut) SetEventType(v string) {
 
 // GetId returns the Id field value
 func (o *EndpointMessageOut) GetId() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -129,7 +129,7 @@ func (o *EndpointMessageOut) SetId(v string) {
 
 // GetPayload returns the Payload field value
 func (o *EndpointMessageOut) GetPayload() map[string]interface{} {
-	if o == nil  {
+	if o == nil {
 		var ret map[string]interface{}
 		return ret
 	}
@@ -153,7 +153,7 @@ func (o *EndpointMessageOut) SetPayload(v map[string]interface{}) {
 
 // GetStatus returns the Status field value
 func (o *EndpointMessageOut) GetStatus() MessageStatus {
-	if o == nil  {
+	if o == nil {
 		var ret MessageStatus
 		return ret
 	}
@@ -177,7 +177,7 @@ func (o *EndpointMessageOut) SetStatus(v MessageStatus) {
 
 // GetTimestamp returns the Timestamp field value
 func (o *EndpointMessageOut) GetTimestamp() time.Time {
-	if o == nil  {
+	if o == nil {
 		var ret time.Time
 		return ret
 	}

--- a/go/internal/openapi/model_endpoint_out.go
+++ b/go/internal/openapi/model_endpoint_out.go
@@ -30,7 +30,7 @@ type EndpointOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewEndpointOut(createdAt time.Time, id string, url string, version int32, ) *EndpointOut {
+func NewEndpointOut(createdAt time.Time, id string, url string, version int32) *EndpointOut {
 	this := EndpointOut{}
 	this.CreatedAt = createdAt
 	var description string = ""
@@ -57,7 +57,7 @@ func NewEndpointOutWithDefaults() *EndpointOut {
 
 // GetCreatedAt returns the CreatedAt field value
 func (o *EndpointOut) GetCreatedAt() time.Time {
-	if o == nil  {
+	if o == nil {
 		var ret time.Time
 		return ret
 	}
@@ -177,7 +177,7 @@ func (o *EndpointOut) SetFilterTypes(v []string) {
 
 // GetId returns the Id field value
 func (o *EndpointOut) GetId() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -201,7 +201,7 @@ func (o *EndpointOut) SetId(v string) {
 
 // GetUrl returns the Url field value
 func (o *EndpointOut) GetUrl() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -225,7 +225,7 @@ func (o *EndpointOut) SetUrl(v string) {
 
 // GetVersion returns the Version field value
 func (o *EndpointOut) GetVersion() int32 {
-	if o == nil  {
+	if o == nil {
 		var ret int32
 		return ret
 	}

--- a/go/internal/openapi/model_endpoint_secret_out.go
+++ b/go/internal/openapi/model_endpoint_secret_out.go
@@ -23,7 +23,7 @@ type EndpointSecretOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewEndpointSecretOut(key string, ) *EndpointSecretOut {
+func NewEndpointSecretOut(key string) *EndpointSecretOut {
 	this := EndpointSecretOut{}
 	this.Key = key
 	return &this
@@ -39,7 +39,7 @@ func NewEndpointSecretOutWithDefaults() *EndpointSecretOut {
 
 // GetKey returns the Key field value
 func (o *EndpointSecretOut) GetKey() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}

--- a/go/internal/openapi/model_endpoint_stats.go
+++ b/go/internal/openapi/model_endpoint_stats.go
@@ -25,7 +25,7 @@ type EndpointStats struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewEndpointStats(fail int32, pending int32, success int32, ) *EndpointStats {
+func NewEndpointStats(fail int32, pending int32, success int32) *EndpointStats {
 	this := EndpointStats{}
 	this.Fail = fail
 	this.Pending = pending
@@ -43,7 +43,7 @@ func NewEndpointStatsWithDefaults() *EndpointStats {
 
 // GetFail returns the Fail field value
 func (o *EndpointStats) GetFail() int32 {
-	if o == nil  {
+	if o == nil {
 		var ret int32
 		return ret
 	}
@@ -67,7 +67,7 @@ func (o *EndpointStats) SetFail(v int32) {
 
 // GetPending returns the Pending field value
 func (o *EndpointStats) GetPending() int32 {
-	if o == nil  {
+	if o == nil {
 		var ret int32
 		return ret
 	}
@@ -91,7 +91,7 @@ func (o *EndpointStats) SetPending(v int32) {
 
 // GetSuccess returns the Success field value
 func (o *EndpointStats) GetSuccess() int32 {
-	if o == nil  {
+	if o == nil {
 		var ret int32
 		return ret
 	}

--- a/go/internal/openapi/model_event_type_in.go
+++ b/go/internal/openapi/model_event_type_in.go
@@ -24,7 +24,7 @@ type EventTypeIn struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewEventTypeIn(description string, name string, ) *EventTypeIn {
+func NewEventTypeIn(description string, name string) *EventTypeIn {
 	this := EventTypeIn{}
 	this.Description = description
 	this.Name = name
@@ -41,7 +41,7 @@ func NewEventTypeInWithDefaults() *EventTypeIn {
 
 // GetDescription returns the Description field value
 func (o *EventTypeIn) GetDescription() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -65,7 +65,7 @@ func (o *EventTypeIn) SetDescription(v string) {
 
 // GetName returns the Name field value
 func (o *EventTypeIn) GetName() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}

--- a/go/internal/openapi/model_event_type_out.go
+++ b/go/internal/openapi/model_event_type_out.go
@@ -24,7 +24,7 @@ type EventTypeOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewEventTypeOut(description string, name string, ) *EventTypeOut {
+func NewEventTypeOut(description string, name string) *EventTypeOut {
 	this := EventTypeOut{}
 	this.Description = description
 	this.Name = name
@@ -41,7 +41,7 @@ func NewEventTypeOutWithDefaults() *EventTypeOut {
 
 // GetDescription returns the Description field value
 func (o *EventTypeOut) GetDescription() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -65,7 +65,7 @@ func (o *EventTypeOut) SetDescription(v string) {
 
 // GetName returns the Name field value
 func (o *EventTypeOut) GetName() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}

--- a/go/internal/openapi/model_event_type_update.go
+++ b/go/internal/openapi/model_event_type_update.go
@@ -23,7 +23,7 @@ type EventTypeUpdate struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewEventTypeUpdate(description string, ) *EventTypeUpdate {
+func NewEventTypeUpdate(description string) *EventTypeUpdate {
 	this := EventTypeUpdate{}
 	this.Description = description
 	return &this
@@ -39,7 +39,7 @@ func NewEventTypeUpdateWithDefaults() *EventTypeUpdate {
 
 // GetDescription returns the Description field value
 func (o *EventTypeUpdate) GetDescription() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}

--- a/go/internal/openapi/model_http_error_out.go
+++ b/go/internal/openapi/model_http_error_out.go
@@ -24,7 +24,7 @@ type HttpErrorOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewHttpErrorOut(code string, detail string, ) *HttpErrorOut {
+func NewHttpErrorOut(code string, detail string) *HttpErrorOut {
 	this := HttpErrorOut{}
 	this.Code = code
 	this.Detail = detail
@@ -41,7 +41,7 @@ func NewHttpErrorOutWithDefaults() *HttpErrorOut {
 
 // GetCode returns the Code field value
 func (o *HttpErrorOut) GetCode() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -65,7 +65,7 @@ func (o *HttpErrorOut) SetCode(v string) {
 
 // GetDetail returns the Detail field value
 func (o *HttpErrorOut) GetDetail() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}

--- a/go/internal/openapi/model_list_response_application_out_.go
+++ b/go/internal/openapi/model_list_response_application_out_.go
@@ -25,7 +25,7 @@ type ListResponseApplicationOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewListResponseApplicationOut(data []ApplicationOut, done bool, ) *ListResponseApplicationOut {
+func NewListResponseApplicationOut(data []ApplicationOut, done bool) *ListResponseApplicationOut {
 	this := ListResponseApplicationOut{}
 	this.Data = data
 	this.Done = done
@@ -42,7 +42,7 @@ func NewListResponseApplicationOutWithDefaults() *ListResponseApplicationOut {
 
 // GetData returns the Data field value
 func (o *ListResponseApplicationOut) GetData() []ApplicationOut {
-	if o == nil  {
+	if o == nil {
 		var ret []ApplicationOut
 		return ret
 	}
@@ -66,7 +66,7 @@ func (o *ListResponseApplicationOut) SetData(v []ApplicationOut) {
 
 // GetDone returns the Done field value
 func (o *ListResponseApplicationOut) GetDone() bool {
-	if o == nil  {
+	if o == nil {
 		var ret bool
 		return ret
 	}

--- a/go/internal/openapi/model_list_response_endpoint_message_out_.go
+++ b/go/internal/openapi/model_list_response_endpoint_message_out_.go
@@ -25,7 +25,7 @@ type ListResponseEndpointMessageOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewListResponseEndpointMessageOut(data []EndpointMessageOut, done bool, ) *ListResponseEndpointMessageOut {
+func NewListResponseEndpointMessageOut(data []EndpointMessageOut, done bool) *ListResponseEndpointMessageOut {
 	this := ListResponseEndpointMessageOut{}
 	this.Data = data
 	this.Done = done
@@ -42,7 +42,7 @@ func NewListResponseEndpointMessageOutWithDefaults() *ListResponseEndpointMessag
 
 // GetData returns the Data field value
 func (o *ListResponseEndpointMessageOut) GetData() []EndpointMessageOut {
-	if o == nil  {
+	if o == nil {
 		var ret []EndpointMessageOut
 		return ret
 	}
@@ -66,7 +66,7 @@ func (o *ListResponseEndpointMessageOut) SetData(v []EndpointMessageOut) {
 
 // GetDone returns the Done field value
 func (o *ListResponseEndpointMessageOut) GetDone() bool {
-	if o == nil  {
+	if o == nil {
 		var ret bool
 		return ret
 	}

--- a/go/internal/openapi/model_list_response_endpoint_out_.go
+++ b/go/internal/openapi/model_list_response_endpoint_out_.go
@@ -25,7 +25,7 @@ type ListResponseEndpointOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewListResponseEndpointOut(data []EndpointOut, done bool, ) *ListResponseEndpointOut {
+func NewListResponseEndpointOut(data []EndpointOut, done bool) *ListResponseEndpointOut {
 	this := ListResponseEndpointOut{}
 	this.Data = data
 	this.Done = done
@@ -42,7 +42,7 @@ func NewListResponseEndpointOutWithDefaults() *ListResponseEndpointOut {
 
 // GetData returns the Data field value
 func (o *ListResponseEndpointOut) GetData() []EndpointOut {
-	if o == nil  {
+	if o == nil {
 		var ret []EndpointOut
 		return ret
 	}
@@ -66,7 +66,7 @@ func (o *ListResponseEndpointOut) SetData(v []EndpointOut) {
 
 // GetDone returns the Done field value
 func (o *ListResponseEndpointOut) GetDone() bool {
-	if o == nil  {
+	if o == nil {
 		var ret bool
 		return ret
 	}

--- a/go/internal/openapi/model_list_response_event_type_out_.go
+++ b/go/internal/openapi/model_list_response_event_type_out_.go
@@ -25,7 +25,7 @@ type ListResponseEventTypeOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewListResponseEventTypeOut(data []EventTypeOut, done bool, ) *ListResponseEventTypeOut {
+func NewListResponseEventTypeOut(data []EventTypeOut, done bool) *ListResponseEventTypeOut {
 	this := ListResponseEventTypeOut{}
 	this.Data = data
 	this.Done = done
@@ -42,7 +42,7 @@ func NewListResponseEventTypeOutWithDefaults() *ListResponseEventTypeOut {
 
 // GetData returns the Data field value
 func (o *ListResponseEventTypeOut) GetData() []EventTypeOut {
-	if o == nil  {
+	if o == nil {
 		var ret []EventTypeOut
 		return ret
 	}
@@ -66,7 +66,7 @@ func (o *ListResponseEventTypeOut) SetData(v []EventTypeOut) {
 
 // GetDone returns the Done field value
 func (o *ListResponseEventTypeOut) GetDone() bool {
-	if o == nil  {
+	if o == nil {
 		var ret bool
 		return ret
 	}

--- a/go/internal/openapi/model_list_response_message_attempt_endpoint_out_.go
+++ b/go/internal/openapi/model_list_response_message_attempt_endpoint_out_.go
@@ -25,7 +25,7 @@ type ListResponseMessageAttemptEndpointOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewListResponseMessageAttemptEndpointOut(data []MessageAttemptEndpointOut, done bool, ) *ListResponseMessageAttemptEndpointOut {
+func NewListResponseMessageAttemptEndpointOut(data []MessageAttemptEndpointOut, done bool) *ListResponseMessageAttemptEndpointOut {
 	this := ListResponseMessageAttemptEndpointOut{}
 	this.Data = data
 	this.Done = done
@@ -42,7 +42,7 @@ func NewListResponseMessageAttemptEndpointOutWithDefaults() *ListResponseMessage
 
 // GetData returns the Data field value
 func (o *ListResponseMessageAttemptEndpointOut) GetData() []MessageAttemptEndpointOut {
-	if o == nil  {
+	if o == nil {
 		var ret []MessageAttemptEndpointOut
 		return ret
 	}
@@ -66,7 +66,7 @@ func (o *ListResponseMessageAttemptEndpointOut) SetData(v []MessageAttemptEndpoi
 
 // GetDone returns the Done field value
 func (o *ListResponseMessageAttemptEndpointOut) GetDone() bool {
-	if o == nil  {
+	if o == nil {
 		var ret bool
 		return ret
 	}

--- a/go/internal/openapi/model_list_response_message_attempt_out_.go
+++ b/go/internal/openapi/model_list_response_message_attempt_out_.go
@@ -25,7 +25,7 @@ type ListResponseMessageAttemptOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewListResponseMessageAttemptOut(data []MessageAttemptOut, done bool, ) *ListResponseMessageAttemptOut {
+func NewListResponseMessageAttemptOut(data []MessageAttemptOut, done bool) *ListResponseMessageAttemptOut {
 	this := ListResponseMessageAttemptOut{}
 	this.Data = data
 	this.Done = done
@@ -42,7 +42,7 @@ func NewListResponseMessageAttemptOutWithDefaults() *ListResponseMessageAttemptO
 
 // GetData returns the Data field value
 func (o *ListResponseMessageAttemptOut) GetData() []MessageAttemptOut {
-	if o == nil  {
+	if o == nil {
 		var ret []MessageAttemptOut
 		return ret
 	}
@@ -66,7 +66,7 @@ func (o *ListResponseMessageAttemptOut) SetData(v []MessageAttemptOut) {
 
 // GetDone returns the Done field value
 func (o *ListResponseMessageAttemptOut) GetDone() bool {
-	if o == nil  {
+	if o == nil {
 		var ret bool
 		return ret
 	}

--- a/go/internal/openapi/model_list_response_message_endpoint_out_.go
+++ b/go/internal/openapi/model_list_response_message_endpoint_out_.go
@@ -25,7 +25,7 @@ type ListResponseMessageEndpointOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewListResponseMessageEndpointOut(data []MessageEndpointOut, done bool, ) *ListResponseMessageEndpointOut {
+func NewListResponseMessageEndpointOut(data []MessageEndpointOut, done bool) *ListResponseMessageEndpointOut {
 	this := ListResponseMessageEndpointOut{}
 	this.Data = data
 	this.Done = done
@@ -42,7 +42,7 @@ func NewListResponseMessageEndpointOutWithDefaults() *ListResponseMessageEndpoin
 
 // GetData returns the Data field value
 func (o *ListResponseMessageEndpointOut) GetData() []MessageEndpointOut {
-	if o == nil  {
+	if o == nil {
 		var ret []MessageEndpointOut
 		return ret
 	}
@@ -66,7 +66,7 @@ func (o *ListResponseMessageEndpointOut) SetData(v []MessageEndpointOut) {
 
 // GetDone returns the Done field value
 func (o *ListResponseMessageEndpointOut) GetDone() bool {
-	if o == nil  {
+	if o == nil {
 		var ret bool
 		return ret
 	}

--- a/go/internal/openapi/model_list_response_message_out_.go
+++ b/go/internal/openapi/model_list_response_message_out_.go
@@ -25,7 +25,7 @@ type ListResponseMessageOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewListResponseMessageOut(data []MessageOut, done bool, ) *ListResponseMessageOut {
+func NewListResponseMessageOut(data []MessageOut, done bool) *ListResponseMessageOut {
 	this := ListResponseMessageOut{}
 	this.Data = data
 	this.Done = done
@@ -42,7 +42,7 @@ func NewListResponseMessageOutWithDefaults() *ListResponseMessageOut {
 
 // GetData returns the Data field value
 func (o *ListResponseMessageOut) GetData() []MessageOut {
-	if o == nil  {
+	if o == nil {
 		var ret []MessageOut
 		return ret
 	}
@@ -66,7 +66,7 @@ func (o *ListResponseMessageOut) SetData(v []MessageOut) {
 
 // GetDone returns the Done field value
 func (o *ListResponseMessageOut) GetDone() bool {
-	if o == nil  {
+	if o == nil {
 		var ret bool
 		return ret
 	}

--- a/go/internal/openapi/model_message_attempt_endpoint_out.go
+++ b/go/internal/openapi/model_message_attempt_endpoint_out.go
@@ -28,7 +28,7 @@ type MessageAttemptEndpointOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewMessageAttemptEndpointOut(id string, response string, responseStatusCode int32, status MessageStatus, timestamp time.Time, ) *MessageAttemptEndpointOut {
+func NewMessageAttemptEndpointOut(id string, response string, responseStatusCode int32, status MessageStatus, timestamp time.Time) *MessageAttemptEndpointOut {
 	this := MessageAttemptEndpointOut{}
 	this.Id = id
 	this.Response = response
@@ -48,7 +48,7 @@ func NewMessageAttemptEndpointOutWithDefaults() *MessageAttemptEndpointOut {
 
 // GetId returns the Id field value
 func (o *MessageAttemptEndpointOut) GetId() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -72,7 +72,7 @@ func (o *MessageAttemptEndpointOut) SetId(v string) {
 
 // GetResponse returns the Response field value
 func (o *MessageAttemptEndpointOut) GetResponse() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -96,7 +96,7 @@ func (o *MessageAttemptEndpointOut) SetResponse(v string) {
 
 // GetResponseStatusCode returns the ResponseStatusCode field value
 func (o *MessageAttemptEndpointOut) GetResponseStatusCode() int32 {
-	if o == nil  {
+	if o == nil {
 		var ret int32
 		return ret
 	}
@@ -120,7 +120,7 @@ func (o *MessageAttemptEndpointOut) SetResponseStatusCode(v int32) {
 
 // GetStatus returns the Status field value
 func (o *MessageAttemptEndpointOut) GetStatus() MessageStatus {
-	if o == nil  {
+	if o == nil {
 		var ret MessageStatus
 		return ret
 	}
@@ -144,7 +144,7 @@ func (o *MessageAttemptEndpointOut) SetStatus(v MessageStatus) {
 
 // GetTimestamp returns the Timestamp field value
 func (o *MessageAttemptEndpointOut) GetTimestamp() time.Time {
-	if o == nil  {
+	if o == nil {
 		var ret time.Time
 		return ret
 	}

--- a/go/internal/openapi/model_message_attempt_out.go
+++ b/go/internal/openapi/model_message_attempt_out.go
@@ -29,7 +29,7 @@ type MessageAttemptOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewMessageAttemptOut(endpointId string, id string, response string, responseStatusCode int32, status MessageStatus, timestamp time.Time, ) *MessageAttemptOut {
+func NewMessageAttemptOut(endpointId string, id string, response string, responseStatusCode int32, status MessageStatus, timestamp time.Time) *MessageAttemptOut {
 	this := MessageAttemptOut{}
 	this.EndpointId = endpointId
 	this.Id = id
@@ -50,7 +50,7 @@ func NewMessageAttemptOutWithDefaults() *MessageAttemptOut {
 
 // GetEndpointId returns the EndpointId field value
 func (o *MessageAttemptOut) GetEndpointId() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -74,7 +74,7 @@ func (o *MessageAttemptOut) SetEndpointId(v string) {
 
 // GetId returns the Id field value
 func (o *MessageAttemptOut) GetId() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -98,7 +98,7 @@ func (o *MessageAttemptOut) SetId(v string) {
 
 // GetResponse returns the Response field value
 func (o *MessageAttemptOut) GetResponse() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -122,7 +122,7 @@ func (o *MessageAttemptOut) SetResponse(v string) {
 
 // GetResponseStatusCode returns the ResponseStatusCode field value
 func (o *MessageAttemptOut) GetResponseStatusCode() int32 {
-	if o == nil  {
+	if o == nil {
 		var ret int32
 		return ret
 	}
@@ -146,7 +146,7 @@ func (o *MessageAttemptOut) SetResponseStatusCode(v int32) {
 
 // GetStatus returns the Status field value
 func (o *MessageAttemptOut) GetStatus() MessageStatus {
-	if o == nil  {
+	if o == nil {
 		var ret MessageStatus
 		return ret
 	}
@@ -170,7 +170,7 @@ func (o *MessageAttemptOut) SetStatus(v MessageStatus) {
 
 // GetTimestamp returns the Timestamp field value
 func (o *MessageAttemptOut) GetTimestamp() time.Time {
-	if o == nil  {
+	if o == nil {
 		var ret time.Time
 		return ret
 	}

--- a/go/internal/openapi/model_message_endpoint_out.go
+++ b/go/internal/openapi/model_message_endpoint_out.go
@@ -31,7 +31,7 @@ type MessageEndpointOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewMessageEndpointOut(createdAt time.Time, id string, status MessageStatus, url string, version int32, ) *MessageEndpointOut {
+func NewMessageEndpointOut(createdAt time.Time, id string, status MessageStatus, url string, version int32) *MessageEndpointOut {
 	this := MessageEndpointOut{}
 	this.CreatedAt = createdAt
 	var description string = ""
@@ -59,7 +59,7 @@ func NewMessageEndpointOutWithDefaults() *MessageEndpointOut {
 
 // GetCreatedAt returns the CreatedAt field value
 func (o *MessageEndpointOut) GetCreatedAt() time.Time {
-	if o == nil  {
+	if o == nil {
 		var ret time.Time
 		return ret
 	}
@@ -179,7 +179,7 @@ func (o *MessageEndpointOut) SetFilterTypes(v []string) {
 
 // GetId returns the Id field value
 func (o *MessageEndpointOut) GetId() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -203,7 +203,7 @@ func (o *MessageEndpointOut) SetId(v string) {
 
 // GetStatus returns the Status field value
 func (o *MessageEndpointOut) GetStatus() MessageStatus {
-	if o == nil  {
+	if o == nil {
 		var ret MessageStatus
 		return ret
 	}
@@ -227,7 +227,7 @@ func (o *MessageEndpointOut) SetStatus(v MessageStatus) {
 
 // GetUrl returns the Url field value
 func (o *MessageEndpointOut) GetUrl() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -251,7 +251,7 @@ func (o *MessageEndpointOut) SetUrl(v string) {
 
 // GetVersion returns the Version field value
 func (o *MessageEndpointOut) GetVersion() int32 {
-	if o == nil  {
+	if o == nil {
 		var ret int32
 		return ret
 	}

--- a/go/internal/openapi/model_message_in.go
+++ b/go/internal/openapi/model_message_in.go
@@ -25,7 +25,7 @@ type MessageIn struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewMessageIn(eventType string, payload map[string]interface{}, ) *MessageIn {
+func NewMessageIn(eventType string, payload map[string]interface{}) *MessageIn {
 	this := MessageIn{}
 	this.EventType = eventType
 	this.Payload = payload
@@ -74,7 +74,7 @@ func (o *MessageIn) SetEventId(v string) {
 
 // GetEventType returns the EventType field value
 func (o *MessageIn) GetEventType() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -98,7 +98,7 @@ func (o *MessageIn) SetEventType(v string) {
 
 // GetPayload returns the Payload field value
 func (o *MessageIn) GetPayload() map[string]interface{} {
-	if o == nil  {
+	if o == nil {
 		var ret map[string]interface{}
 		return ret
 	}

--- a/go/internal/openapi/model_message_out.go
+++ b/go/internal/openapi/model_message_out.go
@@ -28,7 +28,7 @@ type MessageOut struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewMessageOut(eventType string, id string, payload map[string]interface{}, timestamp time.Time, ) *MessageOut {
+func NewMessageOut(eventType string, id string, payload map[string]interface{}, timestamp time.Time) *MessageOut {
 	this := MessageOut{}
 	this.EventType = eventType
 	this.Id = id
@@ -79,7 +79,7 @@ func (o *MessageOut) SetEventId(v string) {
 
 // GetEventType returns the EventType field value
 func (o *MessageOut) GetEventType() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -103,7 +103,7 @@ func (o *MessageOut) SetEventType(v string) {
 
 // GetId returns the Id field value
 func (o *MessageOut) GetId() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -127,7 +127,7 @@ func (o *MessageOut) SetId(v string) {
 
 // GetPayload returns the Payload field value
 func (o *MessageOut) GetPayload() map[string]interface{} {
-	if o == nil  {
+	if o == nil {
 		var ret map[string]interface{}
 		return ret
 	}
@@ -151,7 +151,7 @@ func (o *MessageOut) SetPayload(v map[string]interface{}) {
 
 // GetTimestamp returns the Timestamp field value
 func (o *MessageOut) GetTimestamp() time.Time {
-	if o == nil  {
+	if o == nil {
 		var ret time.Time
 		return ret
 	}

--- a/go/internal/openapi/model_message_status.go
+++ b/go/internal/openapi/model_message_status.go
@@ -25,6 +25,12 @@ const (
 	_2 MessageStatus = 2
 )
 
+var allowedMessageStatusEnumValues = []MessageStatus{
+	0,
+	1,
+	2,
+}
+
 func (v *MessageStatus) UnmarshalJSON(src []byte) error {
 	var value int32
 	err := json.Unmarshal(src, &value)
@@ -32,7 +38,7 @@ func (v *MessageStatus) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := MessageStatus(value)
-	for _, existing := range []MessageStatus{ 0, 1, 2,   } {
+	for _, existing := range allowedMessageStatusEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -40,6 +46,27 @@ func (v *MessageStatus) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid MessageStatus", value)
+}
+
+// NewMessageStatusFromValue returns a pointer to a valid MessageStatus
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewMessageStatusFromValue(v int32) (*MessageStatus, error) {
+	ev := MessageStatus(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for MessageStatus: valid values are %v", v, allowedMessageStatusEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v MessageStatus) IsValid() bool {
+	for _, existing := range allowedMessageStatusEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to MessageStatus value

--- a/go/internal/openapi/model_validation_error.go
+++ b/go/internal/openapi/model_validation_error.go
@@ -25,7 +25,7 @@ type ValidationError struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewValidationError(loc []string, msg string, type_ string, ) *ValidationError {
+func NewValidationError(loc []string, msg string, type_ string) *ValidationError {
 	this := ValidationError{}
 	this.Loc = loc
 	this.Msg = msg
@@ -43,7 +43,7 @@ func NewValidationErrorWithDefaults() *ValidationError {
 
 // GetLoc returns the Loc field value
 func (o *ValidationError) GetLoc() []string {
-	if o == nil  {
+	if o == nil {
 		var ret []string
 		return ret
 	}
@@ -67,7 +67,7 @@ func (o *ValidationError) SetLoc(v []string) {
 
 // GetMsg returns the Msg field value
 func (o *ValidationError) GetMsg() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}
@@ -91,7 +91,7 @@ func (o *ValidationError) SetMsg(v string) {
 
 // GetType returns the Type field value
 func (o *ValidationError) GetType() string {
-	if o == nil  {
+	if o == nil {
 		var ret string
 		return ret
 	}

--- a/go/internal/openapi/response.go
+++ b/go/internal/openapi/response.go
@@ -32,7 +32,7 @@ type APIResponse struct {
 	Payload []byte `json:"-"`
 }
 
-// NewAPIResponse returns a new APIResonse object.
+// NewAPIResponse returns a new APIResponse object.
 func NewAPIResponse(r *http.Response) *APIResponse {
 
 	response := &APIResponse{Response: r}

--- a/go/internal/openapi/utils.go
+++ b/go/internal/openapi/utils.go
@@ -75,7 +75,6 @@ func (v *NullableBool) UnmarshalJSON(src []byte) error {
 	return json.Unmarshal(src, &v.value)
 }
 
-
 type NullableInt struct {
 	value *int
 	isSet bool
@@ -111,7 +110,6 @@ func (v *NullableInt) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
 
 type NullableInt32 struct {
 	value *int32
@@ -149,7 +147,6 @@ func (v *NullableInt32) UnmarshalJSON(src []byte) error {
 	return json.Unmarshal(src, &v.value)
 }
 
-
 type NullableInt64 struct {
 	value *int64
 	isSet bool
@@ -185,7 +182,6 @@ func (v *NullableInt64) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
 
 type NullableFloat32 struct {
 	value *float32
@@ -223,7 +219,6 @@ func (v *NullableFloat32) UnmarshalJSON(src []byte) error {
 	return json.Unmarshal(src, &v.value)
 }
 
-
 type NullableFloat64 struct {
 	value *float64
 	isSet bool
@@ -260,7 +255,6 @@ func (v *NullableFloat64) UnmarshalJSON(src []byte) error {
 	return json.Unmarshal(src, &v.value)
 }
 
-
 type NullableString struct {
 	value *string
 	isSet bool
@@ -296,7 +290,6 @@ func (v *NullableString) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
 
 type NullableTime struct {
 	value *time.Time

--- a/openapitools.json
+++ b/openapitools.json
@@ -2,6 +2,6 @@
   "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "5.0.1"
+    "version": "5.2.0"
   }
 }


### PR DESCRIPTION
The version of openapi-generator we are using has a bug in python where if additional properties are found it will throw an APIException, this means when we modify our API to add additional fields to an endpoint it will break the python library.  this was fixed in https://github.com/OpenAPITools/openapi-generator/pull/8802 which was released in 5.2.0