### PR TITLE
Java: bump dependencies

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -25,8 +25,11 @@ sourceSets {
 dependencies {
     implementation 'io.swagger:swagger-annotations:1.5.24'
     implementation "com.google.code.findbugs:jsr305:3.0.2"
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.14.7'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.1'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.9.1'
+    implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'io.gsonfire:gson-fire:1.8.4'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
     implementation 'org.threeten:threetenbp:1.4.3'
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     testImplementation 'junit:junit:4.13.1'


### PR DESCRIPTION
Should have happened with the 5.2.0 bump was gonna do this in #111, but we should just pull it into a separate PR.