### PR TITLE
Java: APIException set error message to error detail if possible

### DIFF
--- a/java/lib/src/main/java/com/svix/exceptions/ApiException.java
+++ b/java/lib/src/main/java/com/svix/exceptions/ApiException.java
@@ -28,7 +28,7 @@ public class ApiException extends com.svix.internal.ApiException {
             try {
                 Gson gson = new Gson();
                 APIError error = gson.fromJson(responseBody, APIError.class);
-                this.message = error.getDetail();
+                this.message = String.format("%s (%s)", error.getDetail(), error.getCode());
             } catch (Exception e) {
                 this.message = responseBody;
             }

--- a/java/lib/src/main/java/com/svix/exceptions/ApiException.java
+++ b/java/lib/src/main/java/com/svix/exceptions/ApiException.java
@@ -7,4 +7,12 @@ public class ApiException extends com.svix.internal.ApiException {
     public ApiException(final String message, final Throwable throwable, final int code, final Map<String, List<String>> responseHeaders, final String responseBody) {
         super(message, throwable, code, responseHeaders, responseBody);
     }
+
+    public String getMessage() {
+        String msg = super.getMessage();
+        if (msg == "") {
+            msg = this.getResponseBody();
+        }
+        return msg;
+    }
 }

--- a/java/lib/src/main/java/com/svix/exceptions/ApiException.java
+++ b/java/lib/src/main/java/com/svix/exceptions/ApiException.java
@@ -2,17 +2,44 @@ package com.svix.exceptions;
 
 import java.util.Map;
 import java.util.List;
+import com.google.gson.Gson;
+
+class APIError {
+    private String code;
+    private String detail;
+
+    public String getCode() {
+        return this.code;
+    }
+
+    public String getDetail() {
+        return this.detail;
+    }
+}
 
 public class ApiException extends com.svix.internal.ApiException {
+
+    private String message;
+
     public ApiException(final String message, final Throwable throwable, final int code, final Map<String, List<String>> responseHeaders, final String responseBody) {
         super(message, throwable, code, responseHeaders, responseBody);
+
+        if ((message == null || message.isEmpty()) && responseBody != null) {
+            try {
+                Gson gson = new Gson();
+                APIError error = gson.fromJson(responseBody, APIError.class);
+                this.message = error.getDetail();
+            } catch (Exception e) {
+                this.message = responseBody;
+            }
+        }
     }
 
     public String getMessage() {
         String msg = super.getMessage();
-        if (msg == "") {
-            msg = this.getResponseBody();
+        if (msg != null && !msg.isEmpty()) {
+            return msg;
         }
-        return msg;
+        return this.message;
     }
 }


### PR DESCRIPTION
Not all openapi internal exceptions set the message, which when printing, gives you minimal context unless the user calls `getCode()` or `getResponseBody()`.  One solution is to override the getMessage() function to return the body if the message is missing.

A more 'complete' solution is probably to try and parse the body and set the message to the `error detail`, both are trivial, here I parse the body and try to extract the detail, otherwise we default back to the responseBody.

Before:
```
com.svix.exceptions.ApiException:
```

After
```
com.svix.exceptions.ApiException: Invalid token. (authentication_failed)
```

Fixes #129.