### PR TITLE
ruby: Use proper case when requiring 'base64' library

### DIFF
--- a/ruby/lib/svix.rb
+++ b/ruby/lib/svix.rb
@@ -2,7 +2,7 @@
 
 require "json"
 require "openssl"
-require "Base64"
+require "base64"
 
 # API
 require "svix/api/application_api"


### PR DESCRIPTION
Using the latest version of the gem in Ruby 2.7 raises `! Unable to load application: LoadError: cannot load such file -- Base64`

This is because the library needs to be required as 'base64' (no caps)