### PR TITLE
Kotlin close tries to avoid memory leak

### DIFF
--- a/kotlin/templates/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/kotlin/templates/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -338,6 +338,7 @@ import kotlinx.coroutines.delay
             if (response.isSuccessful && response.code < 500) {
                 break
             }
+            response.close()
             delay(sleepTime)
             sleepTime = sleepTime * 2
             response = client.newCall(request).execute()


### PR DESCRIPTION
Though I'm not sure where the message in https://github.com/svix/svix-libs/issues/191 was seen, this looks to  be the root cause of the leak.