### PR TITLE
Ruby: Ensure uri is imported at gem initialization

### DIFF
--- a/ruby/lib/svix.rb
+++ b/ruby/lib/svix.rb
@@ -3,6 +3,7 @@
 require "json"
 require "openssl"
 require "base64"
+require "uri"
 
 # API
 require "svix/api/application_api"


### PR DESCRIPTION
Ran into an issue with order of imports after upgrading to Monterey