### PR TITLE
Python: Update mypy

### DIFF
--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -35,7 +35,7 @@ mypy-extensions==0.4.3
     # via
     #   black
     #   mypy
-mypy==0.812
+mypy==0.931
     # via -r requirements.in/development.txt
 packaging==20.9
     # via pytest
@@ -72,7 +72,7 @@ toml==0.10.2
     #   black
     #   pep517
     #   pytest
-typed-ast==1.4.3
+tomli==2.0.0
     # via mypy
 typing-extensions==3.10.0.0
     # via mypy


### PR DESCRIPTION
Fixes issue with typed-ast being a hard requirement (which is not supported in 3.9)